### PR TITLE
Fix audio player fallback text

### DIFF
--- a/Band-Project/templates/meet-the-band.html
+++ b/Band-Project/templates/meet-the-band.html
@@ -111,7 +111,7 @@
 			<!-- audio player begin -->
 			<div id="audio-player">
 				<audio controls="controls" autoplay preload="auto">
-					<p>You're browser does not support the sudo element.</p>
+					<p>Your browser does not support the audio element.</p>
 				</audio>
 			</div>
 			<!-- audio player end -->


### PR DESCRIPTION
## Summary
- correct fallback sentence for unsupported audio element in `meet-the-band.html`

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6843062b3a508333919f41155bbec2ef