### PR TITLE
Fix throwError handler recursion

### DIFF
--- a/Band-Project/js/controller.js
+++ b/Band-Project/js/controller.js
@@ -92,9 +92,9 @@ angular.module('bandAppControllers', [])
 			// throw an error displaying the player does not exist
 			var failureReason = 'The Audio Player does not exist';
 			// if we catch an error store it for viewing
-			var throwError = function (reason) {
-				$scope.error = throwError(failureReason);
-			};
+                        var throwError = function (reason) {
+                                $scope.error = reason;
+                        };
 		} else {
 			// then start the player
 			playPlaylist.src = audioFiles[currentTrack];


### PR DESCRIPTION
## Summary
- fix recursion in `throwError` handler

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684306be34a88333aaaf25a1bae54230