### PR TITLE
Add Jasmine tests for contact controller

### DIFF
--- a/Band-Project/tests/contactController.spec.js
+++ b/Band-Project/tests/contactController.spec.js
@@ -1,0 +1,24 @@
+const fs = require('fs');
+const path = require('path');
+
+function getStoreFormData() {
+  const file = fs.readFileSync(path.resolve(__dirname, '../js/controller.js'), 'utf8');
+  const match = file.match(/\$scope\.storeFormData\s*=\s*function\s*\(\)\s*{([\s\S]*?)^\s*};/m);
+  if (!match) {
+    throw new Error('storeFormData function not found');
+  }
+  let body = match[1];
+  body = body.replace(/\$scope\./g, 'scope.');
+  return new Function('scope', body);
+}
+
+describe('ContactController storeFormData', function() {
+  it('sets validation messages when form fields are empty', function() {
+    const storeFormData = getStoreFormData();
+    const scope = { collectFormData: {} };
+    storeFormData(scope);
+    expect(scope.firstNameRequired).toBe('First Name Required');
+    expect(scope.lastNameRequired).toBe('Last Name Required');
+    expect(scope.emailRequired).toBe('E-mail Required');
+  });
+});

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "This website demonstrates the technologies used throughout stream 1 showing front end development",
   "main": "index.html",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "jasmine"
   },
   "repository": {
     "type": "git",
@@ -21,5 +21,8 @@
   "bugs": {
     "url": "https://github.com/GunnerJnr/stream-one-final-project/issues"
   },
-  "homepage": "https://github.com/GunnerJnr/stream-one-final-project#readme"
+  "homepage": "https://github.com/GunnerJnr/stream-one-final-project#readme",
+  "devDependencies": {
+    "jasmine": "^5.1.0"
+  }
 }

--- a/spec/support/jasmine.json
+++ b/spec/support/jasmine.json
@@ -1,0 +1,6 @@
+{
+  "spec_dir": "Band-Project/tests",
+  "spec_files": [
+    "**/*[sS]pec.js"
+  ]
+}


### PR DESCRIPTION
## Summary
- add Jasmine as dev dependency and create minimal config
- create contactController.spec verifying validation messages
- wire `npm test` to run Jasmine

## Testing
- `npm test` *(fails: `jasmine` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684306d58e248333a131b0adbda6806e